### PR TITLE
Provide a method to find the library ID

### DIFF
--- a/mlol_client/mlol_client.py
+++ b/mlol_client/mlol_client.py
@@ -803,3 +803,7 @@ class MLOLClient:
         data = self._api_request(method="GET", url=API_ENDPOINTS["userinfo"])
         if data:
             return MLOLApiConverter.get_user(data)
+
+    @staticmethod
+    def search_library_id(search: str) -> List[(str, int)]:
+        return [(i["name"], i["id"]) for i in requests.get(ENDPOINTS["api"]["portals"]).json() if i["name"].find(search) != -1]


### PR DESCRIPTION
I don't like the idea that you try the credentials for all the libraries (even though for most people this is OK). I think that who uses this library should know that the request could be slow and expensive otherwise.